### PR TITLE
Include time.h

### DIFF
--- a/pg_logforward.c
+++ b/pg_logforward.c
@@ -8,6 +8,7 @@
 #include <netinet/in.h>
 #include <sys/types.h>
 #include <sys/socket.h>
+#include <time.h>
 
 #define SYSLOG_NAMES
 #include <syslog.h>


### PR DESCRIPTION
Required for gmtime(), localtime(), strftime(), time(), at least on some
platforms.
