### PR TITLE
syslog timestamp fix

### DIFF
--- a/pg_logforward.c
+++ b/pg_logforward.c
@@ -877,7 +877,7 @@ format_syslog_prefix(struct LogTarget *target, ErrorData *edata, char *msgbuf)
 
 	now = (time_t) log_tv.tv_sec;
 	gmt = gmtime(&now);
-	strftime(ts, sizeof(ts), "%F-%dT%H:%M:%SZ", gmt);
+	strftime(ts, sizeof(ts), "%Y-%m-%dT%H:%M:%SZ", gmt);
 
 	/*
 	 * Syslog message format:


### PR DESCRIPTION
Fixes timestamp in syslog log messages. Currently timestamp is generated like this 2017-01-14-14T13:49:17Z and syslog servers fail to parse messages.